### PR TITLE
Add default config.properties file for data2services drill

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ WORKDIR $TMP_DIR
 
 COPY . .
 
+COPY config.properties /config.properties
+
 RUN mvn clean install -Dmaven.test.skip=true
 
 RUN mkdir $APP_DIR && \

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ format = NQUADS
 
 ```bash
 $ docker run -it --rm --link some-progress:my-progress -v <local dir>:/data r2rml /data/config.properties
+# Where config.properties is placed at the root of the <local dir> volume that is shared with the container
 ```
 **Hint:** check out [official postgresql docker documentation](https://hub.docker.com/_/postgres/)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,28 @@
 $ docker build -t r2rml .
 ```
 
-### The run the R2RML processor, execute the following command:
+### To run R2RML on Drill for data2services project
+
+A default config.properties file is provided for the data2services project.
+
+This file can be find in the root of the container: `/config.properties`
+
+```shell
+docker run -it --rm --link drill:drill -v /data/my_dataset:/data r2rml /config.properties
+```
+
+* Content of the `config.properties` file:
+
+```properties
+connectionURL = jdbc:drill:drillbit=drill:31010
+mappingFile = /data/mapping.ttl
+outputFile = /data/rdf_output.nq
+format = NQUADS
+```
+
+
+
+### To run the R2RML processor, execute the following command:
 
 ```bash
 $ docker run -it --rm --link some-progress:my-progress -v <local dir>:/data r2rml /data/config.properties
@@ -42,7 +63,7 @@ password = bar
 mappingFile = /data/mapping.ttl
 outputFile = /data/output.ttl.gz
 format = TURTLE
-```   
+```
 **Hint:** my-postgres is the name of the link from the docker command above
 
 The output, after passing the properties file as an argument to the R2RML processor, should look as follows:

--- a/config.properties
+++ b/config.properties
@@ -1,0 +1,4 @@
+connectionURL = jdbc:drill:drillbit=drill:31010
+mappingFile = /data/mapping.ttl
+outputFile = /data/rdf_output.nq
+format = NQUADS

--- a/src/main/java/r2rml/model/TriplesMap.java
+++ b/src/main/java/r2rml/model/TriplesMap.java
@@ -186,8 +186,8 @@ public class TriplesMap extends R2RMLResource {
 						// maps (but not referencing object maps) to row
 						List<RDFNode> objects = new ArrayList<RDFNode>();
 						for(ObjectMap om : opm.getObjectMaps()) {
-							RDFNode o = om.generateRDFTerm(row); 
-							if(o != null)
+							RDFNode o = om.generateRDFTerm(row);
+							if(o != null && !o.toString().equals(""))
 								objects.add(o);
 						}
 
@@ -244,7 +244,7 @@ public class TriplesMap extends R2RMLResource {
 						Resource object = psm.generateRDFTerm(parent_row);
 						
 						// if subject or object is NULL, don't generate triples
-						if(subject != null || object != null) {
+						if(subject != null || object != null || !object.toString().equals("")) {
 
 							// Let predicates be the set of generated RDF terms that result 
 							// from applying each of the predicate-object map's predicate 


### PR DESCRIPTION
config.properties file is always the same when running for data2services, so we integrated it directly in the container. But the user can still provide his own config.properties file